### PR TITLE
Added new getLeagueEntryData Method

### DIFF
--- a/lib/lolapi.js
+++ b/lib/lolapi.js
@@ -98,6 +98,13 @@
 
         util.makeRequest(url, 'Error getting league data: ', null, regionAndFunc.callback);
     };
+	
+	League.getLeagueEntryData = function (summonerId, regionOrFunction, callback) {
+        var regionAndFunc = util.getCallbackAndRegion(regionOrFunction, region, callback),
+            url = util.craftUrl(endpoint, regionAndFunc.region, leagueUrl + '/' + summonerId + '/entry?', authKey);
+
+        util.makeRequest(url, 'Error getting league data: ', null, regionAndFunc.callback);
+    };
 
     League.Stats.getPlayerSummary = function (summonerId, season, regionOrFunction, callback) {
         var regionAndFunc = util.getCallbackAndRegion(regionOrFunction, region, callback),


### PR DESCRIPTION
This method gets only the summoners own ranked info.  Uses /v2.3/league/by-summoner/`SummonerID`/entry

also fixed freeToPlay champion check, previously always returned invalid query parameter
