### PR TITLE
Fixed rune and masteries not displaying

### DIFF
--- a/lib/lolapi.js
+++ b/lib/lolapi.js
@@ -101,8 +101,8 @@
 
         util.makeRequest(url, 'Error getting league data: ', null, regionAndFunc.callback);
     };
-	
-	League.getLeagueEntryData = function (summonerId, regionOrFunction, callback) {
+
+    League.getLeagueEntryData = function (summonerId, regionOrFunction, callback) {
         var regionAndFunc = util.getCallbackAndRegion(regionOrFunction, region, callback),
             url = util.craftUrl(endpoint, regionAndFunc.region, leagueUrl + '/' + summonerId + '/entry?', authKey);
 
@@ -123,7 +123,7 @@
         }
 
         url = util.craftUrl(endpoint, regionAndFunc.region,
-            statsUrl + '/' + summonerId + '/summary?' + seasonURL, authKey);
+                statsUrl + '/' + summonerId + '/summary?' + seasonURL, authKey);
         util.makeRequest(url, 'Error getting summary data: ', 'playerStatSummaries', regionAndFunc.callback);
     };
 
@@ -141,25 +141,31 @@
         }
 
         url = util.craftUrl(endpoint, regionAndFunc.region,
-            statsUrl + '/' + summonerId + '/ranked?' + seasonURL, authKey);
+                statsUrl + '/' + summonerId + '/ranked?' + seasonURL, authKey);
         util.makeRequest(url, 'Error getting ranked data: ', 'champions', regionAndFunc.callback);
     };
 
-    League.Summoner.getMasteries = function (summonerId, regionOrFunction, callback) {
+    League.Summoner.getMasteries = function (summonerIds, regionOrFunction, callback) {
+        if(Array.isArray(summonerIds)){
+            summonerIds = summonerIds.join();
+        }
         var regionAndFunc = util.getCallbackAndRegion(regionOrFunction,
-            region,
-            callback),
+                region,
+                callback),
             url = util.craftUrl(endpoint, regionAndFunc.region,
-                summonerUrl + '/' + summonerId + '/masteries?', authKey);
+                    summonerUrl + '/' + summonerIds + '/masteries?', authKey);
 
-        util.makeRequest(url, 'Error getting mastery data: ', 'pages', regionAndFunc.callback);
+        util.makeRequest(url, 'Error getting mastery data: ', null, regionAndFunc.callback);
     };
 
-    League.Summoner.getRunes = function (summonerId, regionOrFunction, callback) {
+    League.Summoner.getRunes = function (summonerIds, regionOrFunction, callback) {
+        if(Array.isArray(summonerIds)){
+            summonerIds = summonerIds.join();
+        }
         var regionAndFunc = util.getCallbackAndRegion(regionOrFunction, region, callback),
-            url = util.craftUrl(endpoint, regionAndFunc.region, summonerUrl + '/' + summonerId + '/runes?', authKey);
+            url = util.craftUrl(endpoint, regionAndFunc.region, summonerUrl + '/' + summonerIds + '/runes?', authKey);
 
-        util.makeRequest(url, 'Error getting rune data: ', 'pages', regionAndFunc.callback);
+        util.makeRequest(url, 'Error getting rune data: ', null, regionAndFunc.callback);
     };
 
     League.Summoner.getByName = function (name, regionOrFunction, callback) {
@@ -186,10 +192,10 @@
         var regionAndFunc = util.getCallbackAndRegion(regionOrFunction, region, callback),
             url = util.craftUrl(endpoint, regionAndFunc.region, summonerUrl + '/' + ids + '/name?', authKey);
 
-        util.makeRequest(url, 'Error getting summoner names using list of ids: ', 'summoners', regionAndFunc.callback);
+        util.makeRequest(url, 'Error getting summoner names using list of ids: ', null, regionAndFunc.callback);
     };
     League.Summoner.listSummonerDataByIDs = function (ids, regionOrFunction, callback) {
-        
+
         if(Array.isArray(ids)){
             ids = ids.join();
         }
@@ -204,7 +210,7 @@
 
         util.makeRequest(url, 'Error getting summoner teams info: ', null, regionAndFunc.callback);
     };
-    
+
     League.setRateLimit  = function (limitPer10s, limitPer10min) {
         util.setRateLimit(limitPer10s, limitPer10min);
     };

--- a/test/leagueApiSpec.js
+++ b/test/leagueApiSpec.js
@@ -16,7 +16,7 @@ describe('League of Legends api wrapper test suite', function () {
 
 
     beforeEach(function () {
-        leagueApi.init('your api key here', 'na');        
+        leagueApi.init('your api key here', 'na');
     });
 
     it('should be able to retrieve all champions', function (done) {
@@ -41,7 +41,18 @@ describe('League of Legends api wrapper test suite', function () {
     it('should throw an error if given the wrong type ', function (done) {
         done();
     });
-    
+
+    it('should be able to list names from list of ids', function(done){
+        leagueApi.Summoner.listNamesByIDs(mockSummonersArray, function(err, res){
+            should.not.exist(err);
+            should.exist(res);
+            mockSummonersArray.forEach(function(id){
+                should.exist(res[id]);
+            });
+            done();
+        });
+    });
+
     it('should be able to summoners data from a list of ids', function (done) {
         leagueApi.Summoner.listSummonerDataByIDs(mockSummonersArray, function (err, res) {
             should.not.exist(err);
@@ -53,52 +64,74 @@ describe('League of Legends api wrapper test suite', function () {
         });
     });
 
-    it('should be able to get champion static data', function(done) {
-        var options = {champData: 'allytips,blurb', version : '4.4.3', locale: 'en_US'};
-        leagueApi.Static.getChampionList(options, 'na', function(err, champs) {
+    it('should be able to get summoner runes', function (done) {
+        leagueApi.Summoner.getRunes(mockSummonersArray, function (err, res) {
+            should.not.exist(err);
+            should.exist(res);
+            mockSummonersArray.forEach(function (id) {
+                should.exist(res[id]);
+            });
+            done();
+        });
+    });
+
+    it('should be able to get summoner masteries', function (done) {
+        leagueApi.Summoner.getMasteries(mockSummonersArray, function (err, res) {
+            should.not.exist(err);
+            should.exist(res);
+            mockSummonersArray.forEach(function (id) {
+                should.exist(res[id]);
+            });
+            done();
+        });
+    });
+
+    it('should be able to get champion static data', function (done) {
+        var options = {champData: 'allytips,blurb', version: '4.4.3', locale: 'en_US'};
+        leagueApi.Static.getChampionList(options, 'na', function (err, champs) {
             should.not.exist(err);
             should.exist(champs);
             done();
         });
     });
 
-    it('should be able to get a list of versions', function(done) {
-        leagueApi.Static.getVersions('na', function(err, vers) {
+    it('should be able to get a list of versions', function (done) {
+        leagueApi.Static.getVersions('na', function (err, vers) {
             should.not.exist(err);
             should.exist(vers);
             done();
         });
     });
 
-    it('should be able to get static data of a champion by id', function(done) {
-        var options = {champData: 'allytips,blurb', version : '4.4.3', locale: 'en_US'};
-        leagueApi.Static.getChampionById(1, options, 'na', function(err, champ) {
+    it('should be able to get static data of a champion by id', function (done) {
+        var options = {champData: 'allytips,blurb', version: '4.4.3', locale: 'en_US'};
+        leagueApi.Static.getChampionById(1, options, 'na', function (err, champ) {
             should.not.exist(err);
             should.exist(champ);
             done();
         });
     });
 
-    it('should be able to get a list of items', function(done) {
-        var options = {champData: 'allytips,blurb', version : '4.4.3', locale: 'en_US'};
-        leagueApi.Static.getItemList(options, 'na', function(err, items) {
+    it('should be able to get a list of items', function (done) {
+        var options = {champData: 'allytips,blurb', version: '4.4.3', locale: 'en_US'};
+        leagueApi.Static.getItemList(options, 'na', function (err, items) {
             should.not.exist(err);
             should.exist(items);
             done();
         });
     });
 
-    it('should be able to get static data of an item by id', function(done) {
-        var options = {champData: 'allytips,blurb', version : '4.4.3', locale: 'en_US'};
-        leagueApi.Static.getItemById(2009, options, 'na', function(err, item) {
+    it('should be able to get static data of an item by id', function (done) {
+        var options = {champData: 'allytips,blurb', version: '4.4.3', locale: 'en_US'};
+        leagueApi.Static.getItemById(2009, options, 'na', function (err, item) {
             should.not.exist(err);
             should.exist(item);
             done();
         });
     });
 
-    it('should be able to get static data of masteries', function(done) {
-        var options = {masteryListData: 'prereq', version : '4.4.3', locale: 'en_US'};
+    it('should be able to get static data of masteries', function (done) {
+        var options = {masteryListData: 'prereq', version: '4.4.3', locale: 'en_US'};
         leagueApi.Static.getMasteryList(options, 'na', function (err, masteries) {
             should.not.exist(err);
             should.exist(masteries);
@@ -106,8 +139,8 @@ describe('League of Legends api wrapper test suite', function () {
         });
     });
 
-    it('should be able to get static data of a mastery by id', function(done) {
-        var options = {masteryData: 'prereq', version : '4.4.3', locale: 'en_US'};
+    it('should be able to get static data of a mastery by id', function (done) {
+        var options = {masteryData: 'prereq', version: '4.4.3', locale: 'en_US'};
         leagueApi.Static.getMasteryById(4353, options, 'na', function (err, mastery) {
             should.not.exist(err);
             should.exist(mastery);
@@ -115,7 +148,7 @@ describe('League of Legends api wrapper test suite', function () {
         });
     });
 
-    it('should be able to get static data of a realm', function(done) {
+    it('should be able to get static data of a realm', function (done) {
         leagueApi.Static.getRealm('na', function (err, realm) {
             should.not.exist(err);
             should.exist(realm);
@@ -123,12 +156,12 @@ describe('League of Legends api wrapper test suite', function () {
         });
     });
 
-    it('should be able to get a new endpoint', function(done) {
+    it('should be able to get a new endpoint', function (done) {
 
-        var currentEndpoint = leagueApi.getEndpoint();        
+        var currentEndpoint = leagueApi.getEndpoint();
         should(currentEndpoint).equal('http://prod.api.pvp.net/api/lol');
-        
-        var newEndpointUrl  = "https://eu.api.pvp.net/api/lol"
+
+        var newEndpointUrl = "https://eu.api.pvp.net/api/lol"
         leagueApi.setEndpoint(newEndpointUrl);
 
         var newEndpoint = leagueApi.getEndpoint();


### PR DESCRIPTION
Masteries and Runes endpoint now allow a comma-delimited list of
summonerIds

This fixes Issue #22
