### PR TITLE
Updated to fix recent changes on Riot's end. Also minor code cleanup.

### DIFF
--- a/lib/lolapi.js
+++ b/lib/lolapi.js
@@ -11,14 +11,21 @@
         util = require('./util'),
         authKey,
         region = 'na',
-        endpoint = 'http://prod.api.pvp.net/api/lol',
-        championUrl = '/v1.1/champion',
+        endpoint = 'api.pvp.net/api/lol',
+        championUrl = '/v1.2/champion',
         gameUrl = '/v1.3/game/by-summoner',
-        leagueUrl = '/v2.3/league/by-summoner',
-        statsUrl = '/v1.2/stats/by-summoner',
+        leagueUrl = '/v2.4/league/by-summoner',
+        statsUrl = '/v1.3/stats/by-summoner',
         summonerUrl = '/v1.4/summoner',
-        teamUrl = '/v2.2/team/by-summoner',
-        staticUrl = '/static-data';
+        teamUrl = '/v2.3/team/by-summoner',
+
+        staticUrl = '/static-data',
+        itemUrl = '/v1.2/item',
+        masteryUrl = '/v1.2/mastery',
+        realmUrl = '/v1.2/realm',
+        runeUrl = '/v1.2/rune',
+        summonerSpellUrl = '/v1.2/summoner-spell',
+        versionUrl = '/v1.2/versions';
 
     League.Stats = {};
 
@@ -223,7 +230,7 @@
         return endpoint;
     };
     League.Static.getChampionList = function(options, regionOrFunction, callback) {
-        var championListUrl = '/v1.2/champion?';
+        var championListUrl = championUrl + '?';
         if(options) {
             if (options.champData) {
                 championListUrl += '&champData=' + options.champData;
@@ -249,7 +256,7 @@
     };
 
     League.Static.getChampionById = function(id, options, regionOrFunction, callback) {
-        var championListUrl = '/v1.2/champion/' + id + '?';
+        var championListUrl = championUrl + '/' + id + '?';
 
         if(options) {
             if (options.champData) {
@@ -271,7 +278,7 @@
     };
 
     League.Static.getItemList = function(options, regionOrFunction, callback) {
-        var itemListUrl = '/v1.2/item?';
+        var itemListUrl = itemUrl + '?';
         if (options) {
             if (options.itemListData) {
                 itemListUrl += '&itemListData=' + options.itemListData;
@@ -292,7 +299,7 @@
     };
 
     League.Static.getItemById = function(id, options, regionOrFunction, callback) {
-        var itemListUrl = '/v1.2/item/' + id + '?';
+        var itemListUrl = itemUrl + '/' + id + '?';
         if (options) {
             if (options.itemData) {
                 itemListUrl += '&itemData=' + options.itemData;
@@ -313,7 +320,7 @@
     };
 
     League.Static.getMasteryList = function(options, regionOrFunction, callback) {
-        var masteryListUrl = '/v1.2/mastery?';
+        var masteryListUrl = masteryUrl + '?';
         if (options) {
             if (options.masteryListData) {
                 masteryListUrl += '&masteryListData=' + options.masteryListData;
@@ -334,7 +341,7 @@
     };
 
     League.Static.getMasteryById = function(id, options, regionOrFunction, callback) {
-        var masteryIdUrl = '/v1.2/mastery/' + id + '?';
+        var masteryIdUrl = masteryUrl + '/' + id + '?';
         if (options) {
             if (options.masteryData) {
                 masteryIdUrl += '&masteryData=' + options.masteryData;
@@ -355,14 +362,14 @@
     };
 
     League.Static.getRealm = function(regionOrFunction, callback) {
-        var realmUrl = '/v1.2/realm?';
+        var realmIdUrl = realmUrl + '?';
         var regionAndFunc = util.getCallbackAndRegion(regionOrFunction, region, callback),
-            url = util.craftUrl(endpoint + staticUrl, regionAndFunc.region, realmUrl + '&', authKey);
+            url = util.craftUrl(endpoint + staticUrl, regionAndFunc.region, realmIdUrl + '&', authKey);
         util.makeRequest(url, 'Error getting realm: ', null, regionAndFunc.callback);
     };
 
     League.Static.getRuneList = function(options, regionOrFunction, callback) {
-        var runeListUrl = '/v1.2/rune?';
+        var runeListUrl = runeUrl + '?';
         if (options) {
             if (options.runeListData) {
                 runeListUrl += '&runeListData=' + options.runeListData;
@@ -383,7 +390,7 @@
     };
 
     League.Static.getRuneById= function(id, options, regionOrFunction, callback) {
-        var runeListUrl = '/v1.2/rune/' + id + '?';
+        var runeListUrl = runeUrl + '/' + id + '?';
         if (options) {
             if (options.runeData) {
                 runeListUrl += '&runeData=' + options.runeData;
@@ -404,58 +411,58 @@
     };
 
     League.Static.getSummonerSpellList = function(options, regionOrFunction, callback) {
-        var summonerSpellUrl = '/v1.2/summoner-spell?';
+        var summonerSpellList = summonerSpellUrl + '?';
         if (options) {
             if (options.spellData) {
-                summonerSpellUrl += '&spellData=' + options.spellData;
+                summonerSpellList += '&spellData=' + options.spellData;
             }
 
             if (options.version) {
-                summonerSpellUrl += '&version=' + options.version;
+                summonerSpellList += '&version=' + options.version;
             }
 
             if (options.locale) {
-                summonerSpellUrl += '&locale=' + options.locale;
+                summonerSpellList += '&locale=' + options.locale;
             }
 
             if (options.dataById) {
-                summonerSpellUrl += '&locale=' + options.locale;
+                summonerSpellList += '&locale=' + options.locale;
             }
         }
 
         var regionAndFunc = util.getCallbackAndRegion(regionOrFunction, region, callback),
-            url = util.craftUrl(endpoint + staticUrl, regionAndFunc.region, summonerSpellUrl + '&', authKey);
+            url = util.craftUrl(endpoint + staticUrl, regionAndFunc.region, summonerSpellList + '&', authKey);
         util.makeRequest(url, 'Error getting summoner spell list : ', null, regionAndFunc.callback);
     };
 
     League.Static.getSummonerSpellById = function(id, options, regionOrFunction, callback) {
-        var summonerSpellUrl = '/v1.2/summoner-spell/' + id + '?';
+        var summonerSpellList = summonerSpellUrl + '/' + id + '?';
         if (options) {
             if (options.spellData) {
-                summonerSpellUrl += '&spellData=' + options.spellData;
+                summonerSpellList += '&spellData=' + options.spellData;
             }
 
             if (options.version) {
-                summonerSpellUrl += '&version=' + options.version;
+                summonerSpellList += '&version=' + options.version;
             }
 
             if (options.locale) {
-                summonerSpellUrl += '&locale=' + options.locale;
+                summonerSpellList += '&locale=' + options.locale;
             }
 
             if (options.dataById) {
-                summonerSpellUrl += '&locale=' + options.locale;
+                summonerSpellList += '&locale=' + options.locale;
             }
         }
 
         var regionAndFunc = util.getCallbackAndRegion(regionOrFunction, region, callback),
-            url = util.craftUrl(endpoint + staticUrl, regionAndFunc.region, summonerSpellUrl + '&', authKey);
+            url = util.craftUrl(endpoint + staticUrl, regionAndFunc.region, summonerSpellList + '&', authKey);
         util.makeRequest(url, 'Error getting summoner spell by id : ', null, regionAndFunc.callback);
     };
 
     League.Static.getVersions = function(regionOrFunction, callback) {
         var regionAndFunc = util.getCallbackAndRegion(regionOrFunction, region, callback),
-            url = util.craftUrl(endpoint + staticUrl, regionAndFunc.region, '/v1.2/versions?', authKey);
+            url = util.craftUrl(endpoint + staticUrl, regionAndFunc.region, versionUrl + '?', authKey);
         util.makeRequest(url, 'Error getting versions: ', null, regionAndFunc.callback);
     };
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -5,7 +5,7 @@
 var http = require('http'), RateLimiter = require('./rateLimiter'), limiterPer10s, limiterPer10min,
 
     craftUrl = function (urlType, region, api, authKey) {
-        return urlType + '/' + region + api + 'api_key=' + authKey;
+        return 'http://' + region + '.' + urlType + '/' + region + api + 'api_key=' + authKey;
     },
     checkLimits = function(callback) {
         if(limiterPer10s === undefined || limiterPer10min === undefined){

--- a/test/leagueApiSpec.js
+++ b/test/leagueApiSpec.js
@@ -159,7 +159,7 @@ describe('League of Legends api wrapper test suite', function () {
     it('should be able to get a new endpoint', function (done) {
 
         var currentEndpoint = leagueApi.getEndpoint();
-        should(currentEndpoint).equal('http://prod.api.pvp.net/api/lol');
+        should(currentEndpoint).equal('api.pvp.net/api/lol');
 
         var newEndpointUrl = "https://eu.api.pvp.net/api/lol"
         leagueApi.setEndpoint(newEndpointUrl);


### PR DESCRIPTION
Updated URLs to new versions and did a bit of code cleanup. Namely, the endpoint is now region dependent on Riot's end, so the code reflects that now. See: https://developer.riotgames.com/discussion/riot-games-api/show/IH27EK1I

**Bug**:
There is a somewhat small inconsistency on Riot's part that I'm sure would make the code bug out.

On calling `lol-static-data-v1.2`: If you call it on `na`, the correct URL is:
`https://na.api.pvp.net/api/lol/static-data/na/v1.2/champion?api_key=blah`

However, if you want to call it on `kr`, the correct URL, according to Riot, is:
`https://prod.api.pvp.net/api/lol/static-data/kr/v1.2/champion?api_key=blah`

(notice how it's not `kr.prod.api`)

According to [this link](https://developer.riotgames.com/docs/regional-endpoints), `static-data` SHOULD use the `na.api.pvp.net` endpoint no matter the region. It would be a very easy fix in the code (though I hate Riot for doing it this way; just seems lazy).
