### PR TITLE
Fixed beginIndex and endIndex in getMatchHistory

### DIFF
--- a/lib/lolapi.js
+++ b/lib/lolapi.js
@@ -140,10 +140,10 @@
                 historyOptions += '&rankedQueues=' + options.rankedQueues.join();
             }
             if (options.beginIndex) {
-                historyOptions += '&version=' + options.beginIndex;
+                historyOptions += '&beginIndex=' + options.beginIndex;
             }
             if (options.endIndex) {
-                historyOptions += '&locale=' + options.endIndex;    
+                historyOptions += '&endIndex=' + options.endIndex;    
             }
             historyOptions += '&';
         }


### PR DESCRIPTION
Before, beginIndex and endIndex were version and locale