### PR TITLE
Correcting the bug when looking up for summoners spell by id

### DIFF
--- a/lib/lolapi.js
+++ b/lib/lolapi.js
@@ -554,7 +554,7 @@
             }
 
             if (options.dataById) {
-                summonerSpellUrl += '&locale=' + options.locale;
+                summonerSpellUrl += '&dataById=' + options.dataById;
             }
             summonerSpellUrl += '&';
         }


### PR DESCRIPTION
I used to API for my League application and had to use the SummonersSpell by id's but it wasn't working.
So I checked your code and found a this tiny bug :)
Here is the correction ! 
Thanks a lot for this project it's helping me a lot !
Have a good one.