### PR TITLE
Errors in the request (wrong region / network issues)

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -45,7 +45,7 @@ var https = require('https'),
             if(path.indexOf('http://') !== -1) {
                 protocol = http;
             }
-            protocol.get(path, function (response) {
+            var req = protocol.get(path, function (response) {
                 response.on('data', function (chunk) {
                     jsonObj += chunk;
                 });
@@ -68,6 +68,10 @@ var https = require('https'),
                         callback(null, jsonObj);
                     }
                 });
+            });
+            
+            req.on('error', function(err) {
+               callback(err); 
             });
         });
     },

--- a/test/leagueApiSpec.js
+++ b/test/leagueApiSpec.js
@@ -236,4 +236,12 @@ describe('League of Legends api wrapper test suite', function () {
             done();
         });
     });
+    
+    it('shoult not be able to get infos from not existing regions', function(done) {
+       leagueApi.Summoner.getByName('', 'eu-na', function(err, sum) {
+           should.exist(err);
+           should.not.exist(sum);
+           done();
+       });
+    });
 });


### PR DESCRIPTION
Errors in the request (wrong region / network issues) now return as an error instead of throwing it from within the library

Added Test to check if it is working. No other test fails because of this change.

Should make handling #40 more easy.