### PR TITLE
Getting summoner by name with special characters doesn't work on some systems

### DIFF
--- a/lib/lolapi.js
+++ b/lib/lolapi.js
@@ -281,7 +281,7 @@
         var regionAndFunc = util.getCallbackAndRegion(regionOrFunction, region, callback),
             url;
 
-        name = name.split(' ').join('');
+        name = encodeURIComponent(name.split(' ').join(''));
         url = util.craftUrl(endpoint, regionAndFunc.region, summonerUrl + '/by-name/' + name + '?', authKey);
 
         return util.makeRequest(url, 'Error getting summoner data using name: ', null, regionAndFunc.callback);

--- a/lib/util.js
+++ b/lib/util.js
@@ -51,6 +51,7 @@ var https = require('https'),
                 });
 
                 response.on('error', function (error) {
+                    console.log("response error", error);
                     callback(error, null);
                 });
 
@@ -59,13 +60,16 @@ var https = require('https'),
                     try {
                         jsonObj = JSON.parse(jsonObj);
                     } catch (e) {
+                        console.log("response end without valid json", response.statusCode);
                         callback(response.statusCode);
                         return;
                     }
 
                     if (jsonObj.status && jsonObj.status.message !== 200) {
+                        console.log("response end with error", jsonObj);
                         callback(jsonObj.status.status_code + ' ' + jsonObj.status.message, null);
                     } else {
+                        console.log("response successful");
                         callback(null, jsonObj);
                     }
                 });

--- a/lib/util.js
+++ b/lib/util.js
@@ -51,25 +51,20 @@ var https = require('https'),
                 });
 
                 response.on('error', function (error) {
-                    console.log("response error", error);
                     callback(error, null);
                 });
 
                 response.on('end', function () {
-                    console.log("got answer: ", jsonObj);
                     try {
                         jsonObj = JSON.parse(jsonObj);
                     } catch (e) {
-                        console.log("response end without valid json", response.statusCode);
                         callback(response.statusCode);
                         return;
                     }
 
                     if (jsonObj.status && jsonObj.status.message !== 200) {
-                        console.log("response end with error", jsonObj);
                         callback(jsonObj.status.status_code + ' ' + jsonObj.status.message, null);
                     } else {
-                        console.log("response successful");
                         callback(null, jsonObj);
                     }
                 });

--- a/lib/util.js
+++ b/lib/util.js
@@ -55,6 +55,7 @@ var https = require('https'),
                 });
 
                 response.on('end', function () {
+                    console.log("got answer: ", jsonObj);
                     try {
                         jsonObj = JSON.parse(jsonObj);
                     } catch (e) {


### PR DESCRIPTION
I had the problem, that calling the api with Summoner.byName('Kîzuna Astin') (notice the circumflex on the i) did result in a 400 and no result from the api server.

The problem occured on my FreeBSD production server. Locally on my ubuntu VM it worked fine.

I solved it by urlencoding the given name. Still works in my ubuntu VM, and finally works on my FreeBSD production server.

(Btw, this is my very first pull request ever on github. If I do something wrong, please tell me ^^')