### PR TITLE
Added tournament api's

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Run `npm install` followed by `node server.js`
     LolApi.Tournament.createTournament = function(name, providerId, callback);
 
     LolApi.Tournament.createCode = function(tournamentId, count, options, callback);
+    LolApi.Tournament.updateCode = function(tournamentCode, options, callback);
 ```
 
 ## LeagueJS Gulp Commands

--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ Run `npm install` followed by `node server.js`
 	LolApi.Static.getSummonerSpellList(options, region, callback);
 	LolApi.Static.getSummonerSpellById(id, options, callback);
 
+    //Only for enabled tournament api keys
+    LolApi.getMatchForTournament(matchId, tournamentCode, [includeTimeline], region, callback);
 ```
 
 ## LeagueJS Gulp Commands

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Run `npm install` followed by `node server.js`
 
     LolApi.Tournament.createCode = function(tournamentId, count, options, callback);
     LolApi.Tournament.updateCode = function(tournamentCode, options, callback);
+    LolApi.Tournament.getCode = function(tournamentCode, callback);
 ```
 
 ## LeagueJS Gulp Commands

--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ Run `npm install` followed by `node server.js`
 
     LolApi.getMatchIdsByTournament(tournamentCode, region, callback);
     LolApi.getMatchIdsByTournament(tournamentCode, callback);
+
+    LolApi.Tournament.createProvider(region, callbackUrl, callback);
 ```
 
 ## LeagueJS Gulp Commands

--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ Run `npm install` followed by `node server.js`
     LolApi.Tournament.createCode = function(tournamentId, count, options, callback);
     LolApi.Tournament.updateCode = function(tournamentCode, options, callback);
     LolApi.Tournament.getCode = function(tournamentCode, callback);
+
+    LolApi.Tournament.getLobbyEventsByCode = function(tournamentCode, callback);
 ```
 
 ## LeagueJS Gulp Commands

--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ Run `npm install` followed by `node server.js`
     LolApi.getMatchIdsByTournament(tournamentCode, callback);
 
     LolApi.Tournament.createProvider(region, callbackUrl, callback);
+
+    LolApi.Tournament.createTournament = function(name, providerId, callback);
 ```
 
 ## LeagueJS Gulp Commands

--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ Run `npm install` followed by `node server.js`
     LolApi.Tournament.createProvider(region, callbackUrl, callback);
 
     LolApi.Tournament.createTournament = function(name, providerId, callback);
+
+    LolApi.Tournament.createCode = function(tournamentId, count, options, callback);
 ```
 
 ## LeagueJS Gulp Commands

--- a/README.md
+++ b/README.md
@@ -145,8 +145,14 @@ Run `npm install` followed by `node server.js`
 	LolApi.Static.getSummonerSpellList(options, region, callback);
 	LolApi.Static.getSummonerSpellById(id, options, callback);
 
-    //Only for enabled tournament api keys
+
+    //The following methods are only for enabled tournament api keys:
+
     LolApi.getMatchForTournament(matchId, tournamentCode, [includeTimeline], region, callback);
+    LolApi.getMatchForTournament(matchId, tournamentCode, [includeTimeline], callback);
+
+    LolApi.getMatchIdsByTournament(tournamentCode, region, callback);
+    LolApi.getMatchIdsByTournament(tournamentCode, callback);
 ```
 
 ## LeagueJS Gulp Commands

--- a/lib/lolapi.js
+++ b/lib/lolapi.js
@@ -653,7 +653,20 @@
         if (typeof options.mapType != 'undefined') bodyData.mapType = options.mapType;
         if (typeof options.metadata != 'undefined') bodyData.metadata = options.metadata;
         
-        return util.makeCustomRequest(url, 'POST', bodyData, 'Error creating tournament: ', null, callback);
+        return util.makeCustomRequest(url, 'POST', bodyData, 'Error creating tournament code: ', null, callback);
+    };
+
+    League.Tournament.updateCode = function(tournamentCode, options, callback) {
+        var url = util.craftTournamentUrl(tournamentEndpoint, 'code/' + tournamentCode + '?', authKey);
+
+        var bodyData = {};
+        if (typeof options.allowedParticipants != 'undefined')
+            bodyData.allowedParticipants = options.allowedParticipants.join(',');
+        if (typeof options.spectatorType != 'undefined') bodyData.spectatorType = options.spectatorType;
+        if (typeof options.pickType != 'undefined') bodyData.pickType = options.pickType;
+        if (typeof options.mapType != 'undefined') bodyData.mapType = options.mapType;
+
+        return util.makeCustomRequest(url, 'PUT', bodyData, 'Error updating tournament code: ', null, callback);
     };
 
     module.exports = League;

--- a/lib/lolapi.js
+++ b/lib/lolapi.js
@@ -669,5 +669,11 @@
         return util.makeCustomRequest(url, 'PUT', bodyData, 'Error updating tournament code: ', null, callback);
     };
 
+    League.Tournament.getCode = function(tournamentCode, callback) {
+        var url = util.craftTournamentUrl(tournamentEndpoint, 'code/' + tournamentCode + '?', authKey);
+
+        return util.makeRequest(url, 'Error getting tournament code: ', null, callback);
+    };
+
     module.exports = League;
 }());

--- a/lib/lolapi.js
+++ b/lib/lolapi.js
@@ -13,6 +13,7 @@
         region = 'na',
         endpoint = 'api.pvp.net/api/lol',
         statusEndpoint = 'status.leagueoflegends.com',
+        tournamentEndpoint = 'api.pvp.net/tournament/public/v1',
         championUrl = '/v1.2/champion',
         gameUrl = '/v1.3/game/by-summoner',
         leagueUrl = {
@@ -31,6 +32,8 @@
     League.Summoner = {};
 
     League.Static = {};
+    
+    League.Tournament = {};
 
     League.init = function (key, regionTag) {
         authKey = key;
@@ -619,6 +622,14 @@
         var regionAndFunc = util.getCallbackAndRegion(regionOrFunction, region, callback),
             url = util.craftStaticUrl(endpoint + staticUrl, regionAndFunc.region, '/v1.2/versions?', authKey);
         return util.makeRequest(url, 'Error getting versions: ', null, regionAndFunc.callback);
+    };
+    
+    League.Tournament.createProvider = function(region, callbackUrl, callback) {
+        var url = util.craftTournamentUrl(tournamentEndpoint, 'provider?', authKey);
+        return util.makeCustomRequest(url, 'POST', {
+            region: region,
+            url: callbackUrl
+        }, 'Error creating tournament provider: ', null, callback);
     };
 
     module.exports = League;

--- a/lib/lolapi.js
+++ b/lib/lolapi.js
@@ -640,5 +640,21 @@
         }, 'Error creating tournament: ', null, callback);
     };
 
+    League.Tournament.createCode = function(tournamentId, count, options, callback) {
+        var url = util.craftTournamentUrl(tournamentEndpoint, 'code?tournamentId=' + tournamentId +
+            '&count=' + count + '&', authKey);
+        
+        var bodyData = {};
+        if (typeof options.teamSize != 'undefined') bodyData.teamSize = options.teamSize;
+        if (typeof options.allowedSummonerIds != 'undefined') 
+            bodyData.allowedSummonerIds = {participants: options.allowedSummonerIds};
+        if (typeof options.spectatorType != 'undefined') bodyData.spectatorType = options.spectatorType;
+        if (typeof options.pickType != 'undefined') bodyData.pickType = options.pickType;
+        if (typeof options.mapType != 'undefined') bodyData.mapType = options.mapType;
+        if (typeof options.metadata != 'undefined') bodyData.metadata = options.metadata;
+        
+        return util.makeCustomRequest(url, 'POST', bodyData, 'Error creating tournament: ', null, callback);
+    };
+
     module.exports = League;
 }());

--- a/lib/lolapi.js
+++ b/lib/lolapi.js
@@ -149,6 +149,15 @@
         return util.makeRequest(url, 'Error getting tournament match: ', null, regionAndFunc.callback);
     };
 
+    League.getMatchIdsByTournament = function(tournamentCode, regionOrFunction, callback) {
+        var url,
+            regionAndFunc = util.getCallbackAndRegion(regionOrFunction, region, callback);
+
+        url = util.craftUrl(endpoint, regionAndFunc.region, matchUrl + '/by-tournament/' +
+            tournamentCode + '/ids?', authKey);
+        return util.makeRequest(url, 'Error getting tournament match ids: ', null, regionAndFunc.callback);
+    };
+
     League.getMatchHistory = function(summonerId, options, regionOrFunction, callback) {
         var url,
             regionAndFunc = util.getCallbackAndRegion(regionOrFunction, region, callback),

--- a/lib/lolapi.js
+++ b/lib/lolapi.js
@@ -632,5 +632,13 @@
         }, 'Error creating tournament provider: ', null, callback);
     };
 
+    League.Tournament.createTournament = function(name, providerId, callback) {
+        var url = util.craftTournamentUrl(tournamentEndpoint, 'tournament?', authKey);
+        return util.makeCustomRequest(url, 'POST', {
+            name: name,
+            providerId: providerId
+        }, 'Error creating tournament: ', null, callback);
+    };
+
     module.exports = League;
 }());

--- a/lib/lolapi.js
+++ b/lib/lolapi.js
@@ -131,6 +131,24 @@
         return util.makeRequest(url, 'Error getting match: ', null, regionAndFunc.callback);
     };
 
+    League.getMatchForTournament = function(matchId, tournamentCode, includeTimelineOrFunction, regionOrFunction, callback) {
+        var url,
+            regionAndFunc;
+        if (typeof(includeTimelineOrFunction) === 'function'){
+            regionAndFunc = util.getCallbackAndRegion(includeTimelineOrFunction, region, callback);
+        } else {
+            regionAndFunc = util.getCallbackAndRegion(regionOrFunction, region, callback);
+        }
+        if (includeTimelineOrFunction) {
+            includeTimelineOrFunction = 'includeTimeline=true&';
+        } else {
+            includeTimelineOrFunction = '';
+        }
+        url = util.craftUrl(endpoint, regionAndFunc.region, matchUrl + '/for-tournament/' +
+            matchId + '?' + includeTimelineOrFunction + 'tournamentCode=' + tournamentCode, authKey);
+        return util.makeRequest(url, 'Error getting tournament match: ', null, regionAndFunc.callback);
+    };
+
     League.getMatchHistory = function(summonerId, options, regionOrFunction, callback) {
         var url,
             regionAndFunc = util.getCallbackAndRegion(regionOrFunction, region, callback),

--- a/lib/lolapi.js
+++ b/lib/lolapi.js
@@ -675,5 +675,11 @@
         return util.makeRequest(url, 'Error getting tournament code: ', null, callback);
     };
 
+    League.Tournament.getLobbyEventsByCode = function(tournamentCode, callback) {
+        var url = util.craftTournamentUrl(tournamentEndpoint, 'lobby/events/by-code/' + tournamentCode + '?', authKey);
+
+        return util.makeRequest(url, 'Error getting lobby events: ', null, callback);
+    };
+
     module.exports = League;
 }());

--- a/lib/lolapi.js
+++ b/lib/lolapi.js
@@ -148,7 +148,7 @@
             includeTimelineOrFunction = '';
         }
         url = util.craftUrl(endpoint, regionAndFunc.region, matchUrl + '/for-tournament/' +
-            matchId + '?' + includeTimelineOrFunction + 'tournamentCode=' + tournamentCode, authKey);
+            matchId + '?' + includeTimelineOrFunction + 'tournamentCode=' + tournamentCode + '&', authKey);
         return util.makeRequest(url, 'Error getting tournament match: ', null, regionAndFunc.callback);
     };
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -82,6 +82,10 @@ var https = require('https'),
                 });
 
                 response.on('end', function () {
+                    if (response.statusCode === 204) {
+                        callback(null, null);
+                    }
+
                     try {
                         jsonObj = JSON.parse(jsonObj);
                     } catch (e) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -52,8 +52,6 @@ var https = require('https'),
             body = JSON.stringify(body);
         }
 
-        console.log(body);
-        
         checkLimits(function (err){
 
             if(err !== undefined){

--- a/lib/util.js
+++ b/lib/util.js
@@ -4,6 +4,7 @@
 
 var https = require('https'),
     http = require('http'),
+    url = require('url'),
     Q = require('q'),
     RateLimiter = require('./rateLimiter'),
     limiterPer10s,
@@ -22,6 +23,9 @@ var https = require('https'),
     craftStatusUrl = function(urlType, api, region) {
         return 'http://' + urlType + api + region;
     },
+    craftTournamentUrl = function(urlType, api, authKey) {
+        return 'https://global.' + urlType + '/' + api + 'api_key=' + authKey;
+    },
     checkLimits = function(callback) {
         if(limiterPer10s === undefined || limiterPer10min === undefined){
             process.nextTick(callback);
@@ -34,18 +38,41 @@ var https = require('https'),
 
     },
 
-    getRequest = function (path, callback) {
+    getRequest = function (requestUrl, method, body, callback) {
         var jsonObj = '',
             protocol = https;
+        
+        if (typeof method == 'function') {
+            callback = method;
+            method = 'GET';
+            body = null;
+        }
+        
+        if (typeof body == 'object') {
+            body = JSON.stringify(body);
+        }
+
+        console.log(body);
+        
         checkLimits(function (err){
 
             if(err !== undefined){
                 callback(err, null);
             }
-            if(path.indexOf('http://') !== -1) {
+            if(requestUrl.indexOf('http://') !== -1) {
                 protocol = http;
             }
-            var req = protocol.get(path, function (response) {
+            var parsedUrl = url.parse(requestUrl);
+            var requestData = {
+                host: parsedUrl.host,
+                path: parsedUrl.path,
+                method: method,
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Content-Length': Buffer.byteLength(body)
+                }
+            };
+            var req = protocol.request(requestData, function (response) {
                 response.on('data', function (chunk) {
                     jsonObj += chunk;
                 });
@@ -73,6 +100,9 @@ var https = require('https'),
             req.on('error', function(err) {
                callback(err); 
             });
+            
+            if (typeof body == 'string') req.write(body);
+            req.end();
         });
     },
 
@@ -101,6 +131,22 @@ var https = require('https'),
             deferred.resolve(data);
         }
 
+        return deferred.promise.nodeify(callback);
+    },
+
+    makeCustomRequest = function(url, method, body, errmsg, key, callback) {
+        var deferred = Q.defer();
+        getRequest(url, method, body, function (err, result) {
+            if (err) {
+                deferred.reject(new Error(errmsg + err));
+            } else {
+                if (key) {
+                    deferred.resolve(result[key]);
+                } else {
+                    deferred.resolve(result);
+                }
+            }
+        });
         return deferred.promise.nodeify(callback);
     },
 
@@ -140,9 +186,11 @@ module.exports = {
     craftObserverUrl: craftObserverUrl,
     craftStatusUrl: craftStatusUrl,
     craftStaticUrl: craftStaticUrl,
+    craftTournamentUrl: craftTournamentUrl,
     getRequest: getRequest,
     makeRequest: makeRequest,
     makeStaticRequest: makeStaticRequest,
+    makeCustomRequest: makeCustomRequest,
     getValidSeasonParam: getValidSeasonParam,
     getCallbackAndRegion: getCallbackAndRegion,
     setRateLimit: setRateLimit


### PR DESCRIPTION
I got an interim tournament api key for my project, so I added all new api's to LeagueJS. The added api's are only available for enabled api keys, so that they don't work with normal api keys.

Because these api's introduced POST/PUT requests, I had to extend the util a little bit to be able to send these requests with a body. Please look into the changes.

I successfully tested all added api's locally with my key. Because they are only working with special api keys, I didn't write specs. I hope that is ok.

See https://developer.riotgames.com/docs/tournaments-api