### PR TITLE
feat (request handling) add response

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -95,7 +95,7 @@ var https = require('https'),
                     }
 
                     if (jsonObj.status && jsonObj.status.message !== 200) {
-                        callback(jsonObj.status.status_code + ' ' + jsonObj.status.message, null);
+                        callback(jsonObj.status.status_code + ' ' + jsonObj.status.message, response);
                     } else {
                         callback(null, jsonObj);
                     }
@@ -115,7 +115,9 @@ var https = require('https'),
         var deferred = Q.defer();
         getRequest(url, function (err, result) {
             if (err) {
-                deferred.reject(new Error(errmsg + err));
+                var error = new Error(errmsg + err);
+                error.headers = result.headers;
+                deferred.reject(error);
             } else {
                 if (key) {
                     deferred.resolve(result[key]);

--- a/lib/util.js
+++ b/lib/util.js
@@ -116,7 +116,9 @@ var https = require('https'),
         getRequest(url, function (err, result) {
             if (err) {
                 var error = new Error(errmsg + err);
-                error.headers = result.headers;
+                if(result){
+                    error.headers = result.headers || {};
+                }
                 deferred.reject(error);
             } else {
                 if (key) {


### PR DESCRIPTION
If error-code is returned from RIOT response object is added to callback in util.getRequest.
Error used for rejection from util.makeRequest has added headers for additional information (e.g. on 429 errors)